### PR TITLE
fix(zsh): scope nvm lazy loading to interactive shells only

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -37,7 +37,12 @@ export ZSH="$HOME/.oh-my-zsh"
 ZSH_THEME=""
 
 # Oh My Zsh NVM lazy loading (must be set before plugins are loaded)
-zstyle ':omz:plugins:nvm' lazy yes
+# Only enable lazy loading for interactive shells. Non-interactive shells
+# (Claude Code Bash tool, CI scripts, `zsh -c`) eagerly source nvm to avoid
+# the lazy wrapper's `_omz_nvm_setup_completion: command not found` noise
+# polluting tool output. Eager load adds ~100-300ms which is invisible in
+# non-interactive contexts but would be felt at every terminal open.
+[[ -o interactive ]] && zstyle ':omz:plugins:nvm' lazy yes
 zstyle ':omz:plugins:nvm' autoload yes
 zstyle ':omz:plugins:nvm' silent-autoload yes
 


### PR DESCRIPTION
## Summary

Fixes `_omz_nvm_setup_completion: command not found` / `_omz_nvm_setup_autoload: command not found` noise appearing on stderr whenever a non-interactive shell invokes `npm`, `npx`, `node`, `yarn`, etc.

### Root cause

oh-my-zsh's nvm plugin defines a lazy-load wrapper around `npm/npx/node/yarn/corepack/...`. On first invocation the wrapper unfunctions itself, sources `nvm.sh`, then calls `_omz_nvm_setup_completion` and `_omz_nvm_setup_autoload`. Those two helpers also unfunction themselves after running once. In non-interactive shells (Claude Code's Bash tool, CI scripts, `zsh -c '…'`) the wrapper ends up calling those helpers after they've already been unfunctioned, producing:

```text
npm:9: command not found: _omz_nvm_setup_completion
npm:10: command not found: _omz_nvm_setup_autoload
```

This pollutes every tool output that shells out to an npm command, making logs noisy and hiding real errors.

### Fix

Guard the `lazy yes` zstyle with `[[ -o interactive ]]`. Interactive shells keep the fast lazy path. Non-interactive shells fall through to the plugin's eager-load branch: `nvm.sh` is sourced once at shell startup, setup functions run immediately, and no wrapper is ever defined — so the broken call site can't be reached.

### Trade-off

Eager loading adds ~100-300ms per spawned non-interactive shell. Invisible in that context (tool calls already take longer) but noticeable at every terminal open, which is why the interactive path still uses lazy loading.

## Test plan

- [ ] Open a new interactive terminal - startup time unchanged (~same as before)
- [ ] Run `zsh -c 'npm --version'` - outputs version cleanly with no `_omz_nvm_setup_*` errors
- [ ] Run `zsh -c 'which nvm'` - shows nvm function (not "not found")
- [ ] Reload an existing Claude Code session and run a command that invokes npm/npx - no stderr noise