### PR TITLE
feat(zsh): pin node default for non-interactive shells via .zshenv

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+# Loaded by every zsh invocation, including non-interactive shells (Claude Code,
+# editors, cron, CI runners). Pins PATH to nvm's default node version so child
+# processes see the right toolchain without sourcing nvm lazily.
+
+export NVM_DIR="$HOME/.nvm"
+
+if [ -s "$NVM_DIR/alias/default" ]; then
+  _NVM_DEFAULT="$(cat "$NVM_DIR/alias/default")"
+  while [ -f "$NVM_DIR/alias/$_NVM_DEFAULT" ]; do
+    _NVM_DEFAULT="$(cat "$NVM_DIR/alias/$_NVM_DEFAULT")"
+  done
+  if [ -d "$NVM_DIR/versions/node/v$_NVM_DEFAULT" ]; then
+    export PATH="$NVM_DIR/versions/node/v$_NVM_DEFAULT/bin:$PATH"
+  else
+    _NVM_LATEST="$(ls -1 "$NVM_DIR/versions/node" 2>/dev/null | grep "^v$_NVM_DEFAULT" | sort -V | tail -1)"
+    [ -n "$_NVM_LATEST" ] && export PATH="$NVM_DIR/versions/node/$_NVM_LATEST/bin:$PATH"
+  fi
+  unset _NVM_DEFAULT _NVM_LATEST
+fi

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -103,6 +103,13 @@ fi
 ln -sf "$HOME/.zsh/.zshrc" "$HOME/.zshrc"
 echo "[ok] ~/.zshrc -> ~/.zsh/.zshrc"
 
+# Back up and replace ~/.zshenv (non-interactive shells read this)
+if [ -f "$HOME/.zshenv" ] && [ ! -L "$HOME/.zshenv" ]; then
+  mv "$HOME/.zshenv" "$HOME/.zshenv.backup-$(date +%Y%m%d-%H%M%S)"
+fi
+ln -sf "$HOME/.zsh/.zshenv" "$HOME/.zshenv"
+echo "[ok] ~/.zshenv -> ~/.zsh/.zshenv"
+
 # Ensure cache dir exists
 mkdir -p "$SCRIPT_DIR/cache"
 


### PR DESCRIPTION
## Summary

- Add `zsh/.zshenv` that resolves `~/.nvm/alias/default` and prepends the matching node bin to `PATH`.
- Symlink `~/.zshenv -> ~/.zsh/.zshenv` from `install.sh`.

## Why

Non-interactive zsh (Claude Code Bash tool, editors, cron, CI runners) does not source `.zshrc`, so the lazy `nvm` plugin never fires. `PATH` ends up pinned to whatever node version the parent process happened to have active, which broke `Promise.try` (Node 22 vs Node 24) when running tests from Claude Code despite `.nvmrc=24`.

`.zshenv` is read by every zsh invocation, so resolving the default alias here guarantees child processes get the right toolchain without the interactive plugin path.

## Test plan

- [ ] Fresh shell: `zsh -c 'node --version'` matches `nvm alias default`.
- [ ] Existing nvm versions still selectable via `nvm use <ver>` in interactive shells.
- [ ] No regression in interactive prompt startup time.